### PR TITLE
setup continous integration to automatically deploy releases to the github release system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - checkout
       - run: go get -u github.com/mitchellh/gox
       - run: go get -u github.com/tcnksm/ghr
+      - run: go get -u github.com/stevenmatthewt/semantics
       - run:
           name: cross compile
           command: gox -os="linux darwin windows" -arch="amd64 386" -output="dist/pligos_{{.OS}}_{{.Arch}}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,17 @@ jobs:
       - run: go get -u github.com/stevenmatthewt/semantics
       - run:
           name: cross compile
-          command: gox -os="linux darwin windows" -arch="amd64 386" -output="dist/pligos_{{.OS}}_{{.Arch}}"
+          command: gox -os="linux darwin windows" -arch="amd64 386" -output="dist/{{.OS}}/{{.Arch}}/pligos"
+
       - add_ssh_keys
       - run:
           name: create release
           command: |-
             tag=$(semantics --output-tag)
+            go run .circleci/package.go $tag
+
             if [ "$tag" ]; then
-              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/
+              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/build
             else
               echo "The commit message(s) did not indicate a major/minor/patch version."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ jobs:
           command: |-
             tag=$(semantics --output-tag)
             if [ "$tag" ]; then
-              echo $tag
-              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME $tag dist/
+              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/
             else
               echo "The commit message(s) did not indicate a major/minor/patch version."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             tag=$(semantics --output-tag)
             if [ "$tag" ]; then
               echo $tag
-              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace "$tag" dist/
+              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME $tag dist/
             else
               echo "The commit message(s) did not indicate a major/minor/patch version."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
       - checkout
       - run: go get -u github.com/mitchellh/gox
       - run: go get -u github.com/tcnksm/ghr
-      - run: go get -u github.com/stevenmatthewt/semantics
       - run:
           name: cross compile
           command: gox -os="linux darwin windows" -arch="amd64 386" -output="dist/pligos_{{.OS}}_{{.Arch}}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2
+jobs:
+
+
+
+  build:
+    docker: [{ image: circleci/golang:1.12 }]
+
+    working_directory: /go/pligos
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-pkg-cache
+
+      - run: go install realcloud.tech/pligos/...
+
+      - save_cache:
+          key: v1-pkg-cache
+          paths:
+            - /go/pkg
+
+
+  publish-github-release:
+    docker: [{ image: circleci/golang:1.8 }]
+    requires: [build]
+    steps:
+      - attach_workspace: {at: /go/bin }
+      - run:
+          name: Publish Release on GitHub
+          command: |
+
+            go get github.com/tcnksm/ghr
+
+            VERSION=test
+
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /go/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2
 jobs:
-
   build:
     docker:
       - image: circleci/golang:1.12
@@ -13,7 +12,6 @@ jobs:
       - run:
           name: cross compile
           command: gox -os="linux darwin windows" -arch="amd64 386" -output="dist/pligos_{{.OS}}_{{.Arch}}"
-
       - add_ssh_keys
       - run:
           name: create release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,26 @@
 version: 2
 jobs:
 
-
-
   build:
-    docker: [{ image: circleci/golang:1.12 }]
-
+    docker:
+      - image: circleci/golang:1.12
     working_directory: /go/pligos
-
     steps:
       - checkout
-
-      - restore_cache:
-          keys:
-            - v1-pkg-cache
-
-      - run: go install realcloud.tech/pligos/...
-
-      - save_cache:
-          key: v1-pkg-cache
-          paths:
-            - /go/pkg
-
-
-  publish-github-release:
-    docker: [{ image: circleci/golang:1.8 }]
-    requires: [build]
-    steps:
-      - attach_workspace: {at: /go/bin }
+      - run: go get -u github.com/mitchellh/gox
+      - run: go get -u github.com/tcnksm/ghr
+      - run: go get -u github.com/stevenmatthewt/semantics
       - run:
-          name: Publish Release on GitHub
-          command: |
+          name: cross compile
+          command: gox -os="linux darwin windows" -arch="amd64 386" -output="dist/pligos_{{.OS}}_{{.Arch}}"
 
-            go get github.com/tcnksm/ghr
-
-            VERSION=test
-
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} /go/bin
+      - add_ssh_keys
+      - run:
+          name: create release
+          command: |-
+            tag=$(semantics --output-tag)
+            if [ "$tag" ]; then
+              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/
+            else
+              echo "The commit message(s) did not indicate a major/minor/patch version."
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
           name: create release
           command: |-
             tag=$(semantics --output-tag)
-            echo $tag
             if [ "$tag" ]; then
-              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/
+              echo $tag
+              ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace "$tag" dist/
             else
               echo "The commit message(s) did not indicate a major/minor/patch version."
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
           name: create release
           command: |-
             tag=$(semantics --output-tag)
+            echo $tag
             if [ "$tag" ]; then
               ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $tag dist/
             else

--- a/.circleci/package.go
+++ b/.circleci/package.go
@@ -37,23 +37,29 @@ func build(releases []release, version string) error {
 		return err
 	}
 
-	plugin["version"] = version
-	pluginYaml, err = yaml.Marshal(plugin)
-	if err != nil {
-		return err
-	}
-
-	pluginDist := filepath.Join("dist", "plugin.yaml")
-	if err := ioutil.WriteFile(pluginDist, pluginYaml, 0644); err != nil {
-		return err
-	}
-
 	if err := os.MkdirAll(filepath.Join("dist", "build"), 0700); err != nil {
 		return err
 	}
 
 	for _, e := range releases {
-		d := filepath.Join("dist", "build", fmt.Sprintf("%s_%s_pligs.tar.gz", e.os, e.arch))
+		plugin["version"] = version
+		hook := fmt.Sprintf("chmod +x $HELM_PLUGIN_DIR/%s", filepath.Base(e.path))
+		plugin["hooks"] = map[string]string{
+			"install": hook,
+			"update":  hook,
+		}
+
+		pluginYaml, err = yaml.Marshal(plugin)
+		if err != nil {
+			return err
+		}
+
+		pluginDist := filepath.Join("dist", "plugin.yaml")
+		if err := ioutil.WriteFile(pluginDist, pluginYaml, 0644); err != nil {
+			return err
+		}
+
+		d := filepath.Join("dist", "build", fmt.Sprintf("%s_%s_pligos.tar.gz", e.os, e.arch))
 
 		if err := archiver.Archive([]string{e.path, pluginDist}, d); err != nil {
 			return err

--- a/.circleci/package.go
+++ b/.circleci/package.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/mholt/archiver"
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	releases, err := releases()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := build(releases, os.Args[1]); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type release struct {
+	os, arch, path string
+}
+
+func build(releases []release, version string) error {
+	pluginYaml, err := ioutil.ReadFile("plugin.yaml")
+	if err != nil {
+		return err
+	}
+
+	var plugin map[string]interface{}
+	if err := yaml.Unmarshal(pluginYaml, &plugin); err != nil {
+		return err
+	}
+
+	plugin["version"] = version
+	pluginYaml, err = yaml.Marshal(plugin)
+	if err != nil {
+		return err
+	}
+
+	pluginDist := filepath.Join("dist", "plugin.yaml")
+	if err := ioutil.WriteFile(pluginDist, pluginYaml, 0644); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Join("dist", "build"), 0700); err != nil {
+		return err
+	}
+
+	for _, e := range releases {
+		d := filepath.Join("dist", "build", fmt.Sprintf("%s_%s_pligs.tar.gz", e.os, e.arch))
+
+		if err := archiver.Archive([]string{e.path, pluginDist}, d); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func releases() ([]release, error) {
+	base := "dist"
+
+	res := make([]release, 0)
+
+	osDirs, err := ioutil.ReadDir(base)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, os := range osDirs {
+		if !os.IsDir() {
+			continue
+		}
+
+		archDirs, err := ioutil.ReadDir(filepath.Join(base, os.Name()))
+		if err != nil {
+			return nil, err
+		}
+		for _, arch := range archDirs {
+			if !arch.IsDir() {
+				continue
+			}
+
+			files, err := ioutil.ReadDir(filepath.Join(base, os.Name(), arch.Name()))
+			if err != nil {
+				return nil, err
+			}
+
+			if len(files) == 0 {
+				continue
+			}
+
+			res = append(
+				res,
+				release{
+					os:   os.Name(),
+					arch: arch.Name(),
+					path: filepath.Join(base, os.Name(), arch.Name(), files[0].Name()),
+				},
+			)
+		}
+	}
+
+	return res, nil
+
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /pligos
+/dist

--- a/README.md
+++ b/README.md
@@ -19,3 +19,19 @@ configs into any form necessary.
 So, what you will end up with is a small set of helm starters (in
 pligos lingua franca they are called flavors) and a pligos
 configuration for each service that map to these flavors.
+
+# Install
+
+## OSX
+
+```
+VERSION=$(curl -s https://api.github.com/repos/mooncamp/pligos/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+helm plugin install https://github.com/mooncamp/pligos/releases/download/${VERSION}/darwin_amd64_pligos.tar.gz
+```
+
+## Linux
+
+```
+VERSION=$(curl -s https://api.github.com/repos/mooncamp/pligos/releases/latest | grep -oP '"tag_name": "\K(.*)(?=")')
+helm plugin install https://github.com/mooncamp/pligos/releases/download/$VERSION/linux_amd64_pligos.tar.gz
+```

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,5 @@
+name: pligos
+description: scalable kubernetes infrastructure management
+command: $HELM_PLUGIN_DIR/pligos
+ignoreFlags: false
+useTunnel: false


### PR DESCRIPTION
The CI is based on circleci. We will need to adjust some of variables, such that this also works with the real-digital repository. What needs to be done:

 * create a circleci free account that is connected to the repository
 * create an ssh RSA deployment key and configure it inside of circleci **and** github
 * create a github API token and install it inside of circleci 
 * change the README to point to the `real-digital/pligos` releases, instead of the fork
 * create a `v0.0.0` release of the `real-digital/pligos` repository, by creating a git tag/release.

I realize that this solution is not as smooth as the solution proposed by 

  https://github.com/databus23/helm-diff

More precisely you need to copy 2 lines of bash, instead of one simple one and you need to pick the correct one, based on your operating system. In contrast we 
 1. don't have to have Go installed on the host system
 2. IMO the version selection is more obvious as it uses the already familiar github release URL 
  3. we can keep the `$HOME/.helm/plugin` directory more clean. `helm-diff` abuses this directory to keep the src and to build the `helm-diff` binary.

Versioning is implemented using the `github.com/stevenmatthewt/semantics` tool which I think makes the versioning mechanism very smooth. The version is of course also propagated to the release pacakge, such that pligos may be updated using `helm plugin update`