### PR TITLE
extend depedency configuration with an 'alias' prop

### DIFF
--- a/pkg/applicationconfig/config.go
+++ b/pkg/applicationconfig/config.go
@@ -31,6 +31,7 @@ type Context struct {
 type Dependency struct {
 	PligosPath string `yaml:"path" filepath:"resolve"`
 	Context    string `yaml:"context"`
+	Alias      string `yaml:"alias"`
 }
 
 func ReadPligosConfig(pligosPath string, contextName string) (PligosConfig, error) {

--- a/pkg/applicationconfig/decode.go
+++ b/pkg/applicationconfig/decode.go
@@ -29,7 +29,7 @@ func tagPligosGenerated(c *chart.Chart) {
 }
 
 func Decode(config PligosConfig) (pligos.Pligos, error) {
-	dependencies := make([]pligos.Pligos, 0, len(config.Context.Dependencies))
+	dependencies := make([]pligos.Dependency, 0, len(config.Context.Dependencies))
 	for _, e := range config.Context.Dependencies {
 		dependencyConfig, err := ReadPligosConfig(e.PligosPath, e.Context)
 		if err != nil {
@@ -41,7 +41,7 @@ func Decode(config PligosConfig) (pligos.Pligos, error) {
 			return pligos.Pligos{}, err
 		}
 
-		dependencies = append(dependencies, dependency)
+		dependencies = append(dependencies, pligos.Dependency{Pligos: dependency, Alias: e.Alias})
 	}
 
 	flavor, err := loader.Load(config.Context.FlavorPath)

--- a/pkg/helmport/create.go
+++ b/pkg/helmport/create.go
@@ -72,9 +72,13 @@ func Transform(p pligos.Pligos) (*chart.Chart, error) {
 
 	transformedDependencies := make([]*chart.Chart, 0, len(p.Dependencies))
 	for _, e := range p.Dependencies {
-		c, err := Transform(e)
+		c, err := Transform(e.Pligos)
 		if err != nil {
 			return nil, err
+		}
+
+		if e.Alias != "" {
+			c.Metadata.Name = e.Alias
 		}
 
 		transformedDependencies = append(transformedDependencies, c)

--- a/pkg/pligos/pligos.go
+++ b/pkg/pligos/pligos.go
@@ -13,5 +13,10 @@ type Pligos struct {
 	Types       map[string]interface{}
 	Instances   map[string]interface{}
 
-	Dependencies []Pligos
+	Dependencies []Dependency
+}
+
+type Dependency struct {
+	Alias  string
+	Pligos Pligos
 }


### PR DESCRIPTION
in order to be aple to implement a 1-n relation between two pligos
configurations we need to be able to alias dependencies. the alias name
is used as the name for the underlying helm chart.